### PR TITLE
Fix Brazilian Portuguese pit exit translation

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -656,7 +656,7 @@ msgid ""
 ""
 msgstr ""
 "Não há nada aqui para escalar. Use \"subir\" ou \"sair\" para sair\n"
-"o poço.\n"
+"do poço.\n"
 ""
 
 msgid ""


### PR DESCRIPTION
## Summary
- correct the Brazilian Portuguese translation about leaving the pit by adding the missing preposition

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf7e1ed8e8832899f003e0bc05b9a5