### PR TITLE
Add translation verification tests

### DIFF
--- a/tests/parser_commands.c
+++ b/tests/parser_commands.c
@@ -26,6 +26,88 @@ configure_locale(void)
         textdomain("advent");
 }
 
+static int
+expect_portuguese_translation(void)
+{
+#ifdef HAVE_GETTEXT
+        const char *language = getenv("LANGUAGE");
+        const char *locale = setlocale(LC_ALL, NULL);
+
+        if (!language || strncmp(language, "pt_BR", 5) != 0)
+                return 0;
+        if (!locale)
+                return 0;
+        if (locale[0] == '\0')
+                return 0;
+        if (strncmp(locale, "pt", 2) == 0 || strncmp(locale, "PT", 2) == 0)
+                return 1;
+        if (strstr(locale, "Portuguese") || strstr(locale, "PORTUGUESE"))
+                return 1;
+        return 0;
+#else
+        return 0;
+#endif
+}
+
+static int
+buffer_contains(const unsigned char *data, size_t size, const char *needle)
+{
+        size_t i;
+        size_t needle_len = strlen(needle);
+
+        if (needle_len == 0)
+                return 1;
+        if (size < needle_len)
+                return 0;
+        for (i = 0; i + needle_len <= size; ++i) {
+                if (memcmp(data + i, needle, needle_len) == 0)
+                        return 1;
+        }
+        return 0;
+}
+
+static void
+check_compiled_translation(const char *msgid, const char *expected)
+{
+        const char *dir = getenv("ADVENTURE_LOCALEDIR");
+        char path[1024];
+        FILE *fp;
+        long raw_size;
+        size_t size;
+        unsigned char *buffer;
+        size_t read;
+
+        assert(dir != NULL);
+        if (snprintf(path, sizeof(path), "%s/pt_BR/LC_MESSAGES/advent.mo", dir) >= (int)sizeof(path))
+                abort();
+
+        fp = fopen(path, "rb");
+        assert(fp != NULL);
+        if (fseek(fp, 0, SEEK_END) != 0)
+                abort();
+        raw_size = ftell(fp);
+        if (raw_size < 0)
+                abort();
+        if (fseek(fp, 0, SEEK_SET) != 0)
+                abort();
+        size = (size_t)raw_size;
+        buffer = malloc(size ? size : 1);
+        assert(buffer != NULL);
+        read = fread(buffer, 1, size, fp);
+        fclose(fp);
+        if (read != size)
+                abort();
+
+        if (!buffer_contains(buffer, size, msgid) ||
+            !buffer_contains(buffer, size, expected)) {
+                free(buffer);
+                abort();
+        }
+        assert(buffer_contains(buffer, size, msgid));
+        assert(buffer_contains(buffer, size, expected));
+        free(buffer);
+}
+
 static void
 check_single_word(void)
 {
@@ -77,6 +159,21 @@ check_too_many_words(void)
         if (status != PARSE_TOO_MANY_WORDS)
                 abort();
         assert(status == PARSE_TOO_MANY_WORDS);
+
+        const char *message = adventure_two_word_error();
+#ifdef HAVE_GETTEXT
+        if (expect_portuguese_translation()) {
+                if (strcmp(message, "Só entendo comandos com duas palavras.") != 0)
+                        abort();
+                assert(strcmp(message, "Só entendo comandos com duas palavras.") == 0);
+        } else if (strcmp(message, "Só entendo comandos com duas palavras.") == 0) {
+                assert(strcmp(message, "Só entendo comandos com duas palavras.") == 0);
+        } else {
+                assert(strcmp(message, "Commands are limited to two significant words.") == 0);
+        }
+#else
+        assert(strcmp(message, "Commands are limited to two significant words.") == 0);
+#endif
 }
 
 static void
@@ -178,6 +275,29 @@ check_catalog_translation(void)
                 abort();
         assert(found);
         assert(matched);
+
+        check_compiled_translation(target, expected);
+}
+
+static void
+check_unknown_flag_translation(void)
+{
+        const char *translated = _("unknown flag: %c\n");
+
+        check_compiled_translation("unknown flag: %c\n", "opção desconhecida: %c\n");
+#ifdef HAVE_GETTEXT
+        if (expect_portuguese_translation()) {
+                if (strcmp(translated, "opção desconhecida: %c\n") != 0)
+                        abort();
+                assert(strcmp(translated, "opção desconhecida: %c\n") == 0);
+        } else if (strcmp(translated, "opção desconhecida: %c\n") == 0) {
+                assert(strcmp(translated, "opção desconhecida: %c\n") == 0);
+        } else {
+                assert(strcmp(translated, "unknown flag: %c\n") == 0);
+        }
+#else
+        assert(strcmp(translated, "unknown flag: %c\n") == 0);
+#endif
 }
 
 int
@@ -190,5 +310,6 @@ main(void)
         check_too_many_words();
         check_stopword_directions();
         check_catalog_translation();
+        check_unknown_flag_translation();
         return 0;
 }


### PR DESCRIPTION
## Summary
- validate that the compiled Portuguese catalog contains critical messages
- assert the localized parser error and flag messages behave correctly even when locale fallback occurs

## Testing
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68cf816079e483288933e94136c3b630