### PR TITLE
Add gettext static library to Docker build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 RUN apk --no-cache add --virtual .build-dependencies \
-  alpine-sdk cmake gettext gettext-dev
+  alpine-sdk cmake gettext gettext-dev gettext-static
 
 WORKDIR /root
 COPY . ./


### PR DESCRIPTION
## Summary
- install the gettext static library in the Docker build stage so libintl is available for static linking

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d096853d6c8328aca452ce9a0e5375